### PR TITLE
Add L10N support for date* widgets /w test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 *.egg-info/
 .tox/
 .idea/
+env/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.coverage
 *.log
 *.pot
 *.pyc
@@ -9,3 +10,4 @@ dist/
 .tox/
 .idea/
 env/
+htmlcov/

--- a/import_export/widgets.py
+++ b/import_export/widgets.py
@@ -119,6 +119,8 @@ class BooleanWidget(Widget):
 
 
 class BaseTemporalWidget(Widget):
+    default_formats = formats.get_format_modules()
+
     def __init__(self, format=None, *args, **kwargs):
         super(BaseTemporalWidget, self).__init__(*args, **kwargs)
         # Set formats to Django's (localized) default INPUT_FORMATS or use the

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,3 +2,4 @@
 sphinx
 mysql-python
 psycopg2==2.6.1
+coverage>=4.3.0

--- a/tests/core/tests/widgets_tests.py
+++ b/tests/core/tests/widgets_tests.py
@@ -91,6 +91,12 @@ class DateTimeWidgetTest(TestCase):
         self.assertEqual(self.widget.clean("13.08.2012 18:00:00"),
                          self.datetime)
 
+    def test_clean_none(self):
+        self.assertEqual(self.widget.clean(None), None)
+
+    def test_clean_instance(self):
+        self.assertEqual(self.widget.clean(self.datetime), self.datetime)
+
     @override_settings(USE_TZ=True)
     def test_use_tz(self):
         self.assertEqual(self.widget.render(self.datetime),

--- a/tests/core/tests/widgets_tests.py
+++ b/tests/core/tests/widgets_tests.py
@@ -135,6 +135,9 @@ class TimeWidgetTest(TestCase):
     def test_clean(self):
         self.assertEqual(self.widget.clean("20:15:00"), self.time)
 
+    def test_clean_invalid_date(self):
+        self.assertRaises(ValueError, self.widget.clean, 'asdf')
+
 
 class DecimalWidgetTest(TestCase):
 

--- a/tests/core/tests/widgets_tests.py
+++ b/tests/core/tests/widgets_tests.py
@@ -30,6 +30,20 @@ class BooleanWidgetTest(TestCase):
         self.assertEqual(self.widget.render(None), "")
 
 
+class BaseTemporalWidgetTest(TestCase):
+
+    def setUp(self):
+        self.date = date(2012, 8, 13)
+
+    def test_default_format(self):
+        self.widget = widgets.BaseTemporalWidget()
+        self.assertEqual(self.widget.render(self.date), "2012-08-13")
+
+    def test_init_format(self):
+        self.widget = widgets.BaseTemporalWidget(format='%d.%m.%Y')
+        self.assertEqual(self.widget.render(self.date), "2012-08-13")
+
+
 class DateWidgetTest(TestCase):
 
     def setUp(self):
@@ -44,6 +58,15 @@ class DateWidgetTest(TestCase):
 
     def test_clean(self):
         self.assertEqual(self.widget.clean("13.08.2012"), self.date)
+
+    def test_clean_none(self):
+        self.assertEqual(self.widget.clean(None), None)
+
+    def test_clean_instance(self):
+        self.assertEqual(self.widget.clean(self.date), self.date)
+
+    def test_clean_invalid_date(self):
+        self.assertRaises(ValueError, self.widget.clean, 'asdf')
 
     @override_settings(USE_TZ=True)
     def test_use_tz(self):


### PR DESCRIPTION
This includes the changes made by jnns in pull request #516. Added gitignore for virtualenv and coverage files. Added 100% coverage for all date/time widgets.